### PR TITLE
Trim commit body to a single line within GhPrList

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,15 +29,30 @@ More details in `:help vim-github-cli` .
 Pull Requests
 .............
 
+
 .. code-block:: vim
 
-    :GhPrBlame     " display PR for line within vim (<c-o> to open in webbrowser)
-    :GhPrBlame -w  " display PR for line in web-browser (also wraps other `gh pr` params)
+    " Display PR that changed line under cursor
+    " (within buffer, <c-o> opens in webbrowser)
+    :GhPrBlame
 
-    :GhPrList                     " display all PRs that changed current file
+    " Supports `gh pr` params
+    :GhPrBlame -w
+    :GhPrBlame -R <repo>
+
+
+.. code-block:: vim
+
+    " Display all PRs that touched file
+    " (within buffer, <Enter> shows PR in vim, <c-o> opens in webbrowser)
+    :GhPrList
+
+    " Also supports `git log` params
     :GhPrList --since=2015/01/01  " also wraps other `git log` params
-    " <Enter> displays PR in vim
-    " <c-o> opens PR in webbrowser
+    :GhPrList -n 10
+
+
+.. code-block:: vim
 
     :GhPrView 100     " display PR #100 in vim
     :GhPrView 100 -w  " display PR #100 in webbrowser

--- a/doc/vim-github-cli.txt
+++ b/doc/vim-github-cli.txt
@@ -36,6 +36,7 @@ PULL REQUESTS                       *vim-github-cli-pull-requests*
 
     :GhPrList                     " display all PRs that changed current file
     :GhPrList --since=2015/01/01  " also wraps other `git log` params
+    :GhPrList -n 10               " last 10 PRs
 
     :GhPrView 100                 " display PR #100 in vim
     :GhPrView 100 -w              " display PR #100 in webbrowser

--- a/plugin/vim_github_cli.vim
+++ b/plugin/vim_github_cli.vim
@@ -11,8 +11,8 @@ endfunction
 
 
 " buffers
-call s:set_config_with_fallback('g:vim_github_cli_opencmd_pr_list', 'vert sb')
-call s:set_config_with_fallback('g:vim_github_cli_opencmd_pr_view', 'vert sb')
+call s:set_config_with_fallback('g:vim_github_cli_opencmd_pr_list', 'sb')
+call s:set_config_with_fallback('g:vim_github_cli_opencmd_pr_view', 'sb')
 
 " hotkeys
 call s:set_config_with_fallback('g:vim_github_cli_pr_view_map',     '<Enter>')

--- a/plugin/vim_github_cli.vim
+++ b/plugin/vim_github_cli.vim
@@ -37,6 +37,7 @@ command -nargs=* GhPrBlame :call vim_github_cli#pr#blame(<f-args>)
 "
 " Example
 "   :GhPrList
+"   :GhPrList -n 10
 "   :GhPrList --since=2015/01/01
 "
 command -nargs=* GhPrList :call vim_github_cli#pr#list(<f-args>)


### PR DESCRIPTION
- PrList/PrView default to horiz splits
- GhPrList truncates commit body at newline
- Readability revisions to docs
